### PR TITLE
Restrict test workflow to dev branch only

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,7 @@ name: Run Tests
 
 on:
   push:
-    branches: [dev, main]
+    branches: [dev]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
Limit the test workflow to trigger only on pushes to the dev branch, enhancing workflow efficiency.